### PR TITLE
[Step8] 비즈니스 로직 통합테스트 및 API 로직 주입하기

### DIFF
--- a/src/main/kotlin/com/example/hhplus_ecommerce/api/balance/BalanceApi.kt
+++ b/src/main/kotlin/com/example/hhplus_ecommerce/api/balance/BalanceApi.kt
@@ -4,6 +4,7 @@ import com.example.hhplus_ecommerce.api.balance.request.BalanceChargeRequest
 import com.example.hhplus_ecommerce.api.balance.response.BalanceChargeResponse
 import com.example.hhplus_ecommerce.api.balance.response.UserBalanceResponse
 import com.example.hhplus_ecommerce.api.error.ErrorBody
+import com.example.hhplus_ecommerce.domain.balance.BalanceService
 import com.example.hhplus_ecommerce.exception.BadRequestException
 import com.example.hhplus_ecommerce.exception.NotFoundException
 import io.swagger.v3.oas.annotations.Operation
@@ -19,7 +20,7 @@ import org.springframework.web.bind.annotation.*
 @Tag(name = "잔액 API")
 @RequestMapping("/api/v1")
 @RestController
-class BalanceApi() {
+class BalanceApi(private val balanceService: BalanceService) {
 	@PostMapping("/balances")
 	@Operation(summary = "잔액 충전", description = "사용자의 잔액을 충전한다.")
 	@ApiResponses(value = [
@@ -31,7 +32,10 @@ class BalanceApi() {
 	fun chargeBalance(@RequestBody chargeRequest: BalanceChargeRequest): ResponseEntity<Any> {
 		try {
 			return ResponseEntity.ok(
-				BalanceChargeResponse(12345L, 10000, 30000)
+				BalanceChargeResponse.of(
+					balanceService.updateAmountCharge(chargeRequest.userId, chargeRequest.amount),
+					chargeRequest.amount
+				)
 			)
 		} catch (e: BadRequestException) {
 			return ResponseEntity(ErrorBody(e.errorStatus.message, 400), HttpStatus.BAD_REQUEST)
@@ -52,7 +56,7 @@ class BalanceApi() {
 	fun fetchUserCurrentBalance(@PathVariable userId: Long): ResponseEntity<Any> {
 		try {
 			return ResponseEntity.ok(
-				UserBalanceResponse(12345L, 30000)
+				UserBalanceResponse.from(balanceService.getByUserIdWithLock(userId))
 			)
 		} catch (e: NotFoundException) {
 			return ResponseEntity(ErrorBody(e.errorStatus.message, 404), HttpStatus.NOT_FOUND)

--- a/src/main/kotlin/com/example/hhplus_ecommerce/api/cart/CartApi.kt
+++ b/src/main/kotlin/com/example/hhplus_ecommerce/api/cart/CartApi.kt
@@ -4,7 +4,8 @@ import com.example.hhplus_ecommerce.api.cart.request.CartAddRequest
 import com.example.hhplus_ecommerce.api.cart.response.CartCommandResponse
 import com.example.hhplus_ecommerce.api.cart.response.CartQueryResponse
 import com.example.hhplus_ecommerce.api.error.ErrorBody
-import com.example.hhplus_ecommerce.domain.cart.dto.CartResponseItem
+import com.example.hhplus_ecommerce.domain.cart.CartService
+import com.example.hhplus_ecommerce.domain.cart.dto.CartDto
 import com.example.hhplus_ecommerce.exception.BadRequestException
 import com.example.hhplus_ecommerce.exception.NotFoundException
 import io.swagger.v3.oas.annotations.Operation
@@ -20,7 +21,7 @@ import org.springframework.web.bind.annotation.*
 @Tag(name = "장바구니 API")
 @RequestMapping("/api/v1")
 @RestController
-class CartApi() {
+class CartApi(private val cartService: CartService) {
 	/**
 	 * 장바구니 상품 추가 API
 	 */
@@ -35,11 +36,9 @@ class CartApi() {
 	fun addCartItem(@RequestBody cartAddRequest: CartAddRequest): ResponseEntity<Any> {
 		try {
 			return ResponseEntity.ok(
-				CartCommandResponse(
+				CartCommandResponse.of(
 					"상품을 장바구니에 추가했습니다.",
-					12345L,
-					CartResponseItem(1L, 2
-					)
+					cartService.addProductCart(CartDto.from(cartAddRequest))
 				)
 			)
 		} catch (e: BadRequestException) {
@@ -64,10 +63,9 @@ class CartApi() {
 	): ResponseEntity<Any> {
 		try {
 			return ResponseEntity.ok(
-				CartCommandResponse(
+				CartCommandResponse.of(
 					"장바구니에서 상품을 삭제했습니다.",
-					12345L,
-					CartResponseItem(2L, 1)
+					cartService.deleteCartByUserProduct(userId, productId)
 				)
 			)
 		} catch (e: NotFoundException) {
@@ -89,12 +87,9 @@ class CartApi() {
 	fun getCartsByUser(@PathVariable userId: Long): ResponseEntity<Any> {
 		try {
 			return ResponseEntity.ok(
-				CartQueryResponse(
-					12345L,
-					listOf(
-						CartResponseItem(1L, 2),
-						CartResponseItem(2L, 1)
-					)
+				CartQueryResponse.of(
+					userId,
+					cartService.getAllCartsByUser(userId)
 				)
 			)
 		} catch (e: NotFoundException) {

--- a/src/main/kotlin/com/example/hhplus_ecommerce/api/order/OrderApi.kt
+++ b/src/main/kotlin/com/example/hhplus_ecommerce/api/order/OrderApi.kt
@@ -3,10 +3,9 @@ package com.example.hhplus_ecommerce.api.order
 import com.example.hhplus_ecommerce.api.error.ErrorBody
 import com.example.hhplus_ecommerce.api.order.request.OrderRequest
 import com.example.hhplus_ecommerce.api.order.response.OrderResponse
-import com.example.hhplus_ecommerce.domain.order.OrderStatus
-import com.example.hhplus_ecommerce.domain.order.dto.OrderItemDetailInfo
 import com.example.hhplus_ecommerce.exception.BadRequestException
 import com.example.hhplus_ecommerce.exception.NotFoundException
+import com.example.hhplus_ecommerce.usecase.order.OrderFacade
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -19,12 +18,11 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.time.LocalDateTime
 
 @Tag(name = "주문 API")
 @RequestMapping("/api/v1")
 @RestController
-class OrderApi() {
+class OrderApi(private val orderFacade: OrderFacade) {
 	/**
 	 * 주문 API
 	 */
@@ -41,16 +39,8 @@ class OrderApi() {
 	fun order(@RequestBody orderRequest: OrderRequest): ResponseEntity<Any> {
 		try {
 			return ResponseEntity.ok(
-				OrderResponse(
-					98765L,
-					12345L,
-					LocalDateTime.of(2024, 10, 6, 12, 0, 1),
-					13000,
-					OrderStatus.ORDER_COMPLETE,
-					listOf(
-						OrderItemDetailInfo(1L, 2, 10000),
-						OrderItemDetailInfo(2L, 1, 3000)
-					)
+				OrderResponse.from(
+					orderFacade.productOrder(orderRequest.userId, orderRequest.orderItemInfos)
 				)
 			)
 		} catch (badRequestException: BadRequestException) {

--- a/src/main/kotlin/com/example/hhplus_ecommerce/api/payment/PaymentApi.kt
+++ b/src/main/kotlin/com/example/hhplus_ecommerce/api/payment/PaymentApi.kt
@@ -5,6 +5,7 @@ import com.example.hhplus_ecommerce.api.payment.request.PaymentRequest
 import com.example.hhplus_ecommerce.api.payment.response.PaymentResponse
 import com.example.hhplus_ecommerce.exception.BadRequestException
 import com.example.hhplus_ecommerce.exception.NotFoundException
+import com.example.hhplus_ecommerce.usecase.payment.PaymentFacade
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -17,12 +18,11 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.time.LocalDateTime
 
 @Tag(name = "결제 API")
 @RequestMapping("/api/v1")
 @RestController
-class PaymentApi() {
+class PaymentApi(private val paymentFacade: PaymentFacade) {
 	/**
 	 * 결제 API
 	 */
@@ -39,12 +39,7 @@ class PaymentApi() {
 	fun payment(@RequestBody paymentRequest: PaymentRequest): ResponseEntity<Any> {
 		try {
 			return ResponseEntity.ok(
-				PaymentResponse(
-					123L,
-					98765L,
-					17000,
-					LocalDateTime.of(2024, 10, 6, 12, 1, 10)
-				)
+				PaymentResponse.from(paymentFacade.orderPayment(paymentRequest.userId, paymentRequest.orderId))
 			)
 		} catch (badRequestException: BadRequestException) {
 			return ResponseEntity(ErrorBody(badRequestException.errorStatus.message, 400), HttpStatus.BAD_REQUEST)

--- a/src/main/kotlin/com/example/hhplus_ecommerce/api/product/ProductApi.kt
+++ b/src/main/kotlin/com/example/hhplus_ecommerce/api/product/ProductApi.kt
@@ -3,6 +3,7 @@ package com.example.hhplus_ecommerce.api.product
 import com.example.hhplus_ecommerce.api.error.ErrorBody
 import com.example.hhplus_ecommerce.api.product.response.ProductResponse
 import com.example.hhplus_ecommerce.api.product.response.ProductResponseItem
+import com.example.hhplus_ecommerce.domain.product.ProductService
 import com.example.hhplus_ecommerce.exception.NotFoundException
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -22,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController
 @Tag(name = "상품 API")
 @RequestMapping("/api/v1")
 @RestController
-class ProductApi() {
+class ProductApi(private val productService: ProductService) {
 	/**
 	 * 상품 목록 조회 API
 	 */
@@ -37,12 +38,7 @@ class ProductApi() {
 	fun getProducts(@PageableDefault(size = 10, page = 1) pageable: Pageable): ResponseEntity<Any> {
 		try {
 			return ResponseEntity.ok(
-				ProductResponse(
-					listOf(
-						ProductResponseItem(1L, "상품 A", 5000, 10),
-						ProductResponseItem(2L, "상품 B", 3000, 5),
-					)
-				)
+				ProductResponse.from(productService.getAllProductInfosWithPaging(pageable))
 			)
 		} catch (e: NotFoundException) {
 			return ResponseEntity(ErrorBody(e.errorStatus.message, 404), HttpStatus.NOT_FOUND)
@@ -63,7 +59,7 @@ class ProductApi() {
 	fun getProduct(@PathVariable productId: Long): ResponseEntity<Any> {
 		try {
 			return ResponseEntity.ok(
-				ProductResponseItem(1L, "상품 A", 5000, 10),
+				ProductResponseItem.from(productService.getProductInfoById(productId))
 			)
 		} catch (e: NotFoundException) {
 			return ResponseEntity(ErrorBody(e.errorStatus.message, 404), HttpStatus.NOT_FOUND)

--- a/src/main/kotlin/com/example/hhplus_ecommerce/api/statistics/StatisticApi.kt
+++ b/src/main/kotlin/com/example/hhplus_ecommerce/api/statistics/StatisticApi.kt
@@ -2,8 +2,8 @@ package com.example.hhplus_ecommerce.api.statistics
 
 import com.example.hhplus_ecommerce.api.error.ErrorBody
 import com.example.hhplus_ecommerce.api.statistics.response.OrderProductStatisticsResponse
-import com.example.hhplus_ecommerce.domain.statistics.dto.OrderProductStatisticsResponseItem
 import com.example.hhplus_ecommerce.exception.NotFoundException
+import com.example.hhplus_ecommerce.usecase.statistics.StatisticsFacade
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController
 @Tag(name = "통계 API")
 @RequestMapping("/api/v1")
 @RestController
-class StatisticApi {
+class StatisticApi(private val statisticsFacade: StatisticsFacade) {
 	/**
 	 * 상위 상품 조회 API
 	 */
@@ -35,10 +35,8 @@ class StatisticApi {
 		try {
 			return ResponseEntity.ok(
 				OrderProductStatisticsResponse(
-					listOf(
-						OrderProductStatisticsResponseItem(1L, "상품 A", 50),
-						OrderProductStatisticsResponseItem(2L, "상품 B", 40)
-					)
+					// 최근 3일 간 가장 많이 주문한 상품 상위 5개
+					statisticsFacade.getTopOrderProductStatistics(3, 5)
 				)
 			)
 		} catch (e: NotFoundException) {

--- a/src/main/kotlin/com/example/hhplus_ecommerce/exception/ExternalRequestException.kt
+++ b/src/main/kotlin/com/example/hhplus_ecommerce/exception/ExternalRequestException.kt
@@ -1,0 +1,4 @@
+package com.example.hhplus_ecommerce.exception
+
+class ExternalRequestException(override val message: String) : RuntimeException() {
+}

--- a/src/main/kotlin/com/example/hhplus_ecommerce/infrastructure/external/ExternalDataPlatform.kt
+++ b/src/main/kotlin/com/example/hhplus_ecommerce/infrastructure/external/ExternalDataPlatform.kt
@@ -1,10 +1,15 @@
 package com.example.hhplus_ecommerce.infrastructure.external
 
 import com.example.hhplus_ecommerce.domain.payment.dto.PaymentResultInfo
+import com.example.hhplus_ecommerce.exception.ExternalRequestException
 
 class ExternalDataPlatform {
 	fun sendPaymentData(paymentResultInfo: PaymentResultInfo) {
-		println("외부 데이터 플랫폼에 전송 성공. " +
-			"[paymentId = ${paymentResultInfo.paymentId}, orderId = ${paymentResultInfo.orderId}, 결제 일자 = ${paymentResultInfo.paymentDate}]")
+		// 외부 플랫폼 요청 중 예외 발생했다고 가정
+		try {
+			throw ExternalRequestException("Error:: 외부 데이터 플랫폼에 전송 중 예외 발생")
+		} catch (e: Exception) {
+			println(e.message)
+		}
 	}
 }

--- a/src/main/kotlin/com/example/hhplus_ecommerce/infrastructure/external/ExternalDataPlatform.kt
+++ b/src/main/kotlin/com/example/hhplus_ecommerce/infrastructure/external/ExternalDataPlatform.kt
@@ -6,10 +6,6 @@ import com.example.hhplus_ecommerce.exception.ExternalRequestException
 class ExternalDataPlatform {
 	fun sendPaymentData(paymentResultInfo: PaymentResultInfo) {
 		// 외부 플랫폼 요청 중 예외 발생했다고 가정
-		try {
-			throw ExternalRequestException("Error:: 외부 데이터 플랫폼에 전송 중 예외 발생")
-		} catch (e: Exception) {
-			println(e.message)
-		}
+		throw ExternalRequestException("Error:: 외부 데이터 플랫폼에 전송 중 예외 발생")
 	}
 }

--- a/src/main/kotlin/com/example/hhplus_ecommerce/infrastructure/order/OrderItemJpaRepository.kt
+++ b/src/main/kotlin/com/example/hhplus_ecommerce/infrastructure/order/OrderItemJpaRepository.kt
@@ -9,7 +9,11 @@ import org.springframework.data.repository.query.Param
 import java.time.LocalDateTime
 
 interface OrderItemJpaRepository : JpaRepository<OrderItem, Long> {
-	@Query("SELECT new com.example.hhplus_ecommerce.domain.order.dto.OrderQuantityStatisticsInfo(oi.productDetailId, SUM(oi.quantity)) FROM OrderItem oi WHERE oi.createdDate >= :standardDate ORDER BY SUM(oi.quantity) DESC")
+	@Query("SELECT new com.example.hhplus_ecommerce.domain.order.dto.OrderQuantityStatisticsInfo(oi.productDetailId, SUM(oi.quantity)) " +
+		"FROM OrderItem oi " +
+		"WHERE oi.createdDate >= :standardDate " +
+		"GROUP BY oi.productDetailId " +
+		"ORDER BY SUM(oi.quantity) DESC")
 	fun findTopQuantityByCreatedDateMoreThan(@Param("standardDate") standardDate: LocalDateTime, pageable: Pageable): List<OrderQuantityStatisticsInfo>
 
 	fun findAllByOrderId(orderId: Long): List<OrderItem>

--- a/src/main/kotlin/com/example/hhplus_ecommerce/infrastructure/order/OrderItemJpaRepository.kt
+++ b/src/main/kotlin/com/example/hhplus_ecommerce/infrastructure/order/OrderItemJpaRepository.kt
@@ -11,4 +11,6 @@ import java.time.LocalDateTime
 interface OrderItemJpaRepository : JpaRepository<OrderItem, Long> {
 	@Query("SELECT new com.example.hhplus_ecommerce.domain.order.dto.OrderQuantityStatisticsInfo(oi.productDetailId, SUM(oi.quantity)) FROM OrderItem oi WHERE oi.createdDate >= :standardDate ORDER BY SUM(oi.quantity) DESC")
 	fun findTopQuantityByCreatedDateMoreThan(@Param("standardDate") standardDate: LocalDateTime, pageable: Pageable): List<OrderQuantityStatisticsInfo>
+
+	fun findAllByOrderId(orderId: Long): List<OrderItem>
 }

--- a/src/test/kotlin/com/example/hhplus_ecommerce/domain/balance/BalanceServiceIntegrationTest.kt
+++ b/src/test/kotlin/com/example/hhplus_ecommerce/domain/balance/BalanceServiceIntegrationTest.kt
@@ -1,0 +1,147 @@
+package com.example.hhplus_ecommerce.domain.balance
+
+import com.example.hhplus_ecommerce.api.error.ErrorStatus
+import com.example.hhplus_ecommerce.exception.BadRequestException
+import com.example.hhplus_ecommerce.infrastructure.balance.BalanceHistoryJpaRepository
+import com.example.hhplus_ecommerce.infrastructure.balance.BalanceJpaRepository
+import com.example.hhplus_ecommerce.infrastructure.balance.entity.Balance
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+@SpringBootTest
+class BalanceServiceIntegrationTest {
+	@Autowired private lateinit var balanceService: BalanceService
+	@Autowired private lateinit var balanceRepository: BalanceJpaRepository
+	@Autowired private lateinit var balanceHistoryRepository: BalanceHistoryJpaRepository
+
+	@BeforeEach
+	fun clearDB() {
+		balanceRepository.deleteAll()
+		balanceHistoryRepository.deleteAll()
+	}
+
+	@Test
+	@DisplayName("잔액 차감 - 한 번 차감 수행")
+	fun balanceDecreaseOnce() {
+		val balance = Balance(1L, 10000)
+		balanceRepository.save(balance)
+
+		balanceService.updateAmountDecrease(1L, 8000)
+		val actual = balanceService.getByUserIdWithLock(1L)
+
+		assertThat(actual.amount).isEqualTo(2000)
+	}
+
+	@Test
+	@DisplayName("잔액 차감 - 잔액이 부족할 경우 예외 케이스")
+	fun shouldFailAmountNotEnough() {
+		val balance = Balance(1L, 5000)
+		balanceRepository.save(balance)
+
+		assertThatThrownBy { balanceService.updateAmountDecrease(1L, 10000) }
+			.isInstanceOf(BadRequestException::class.java)
+			.extracting("errorStatus")
+			.isEqualTo(ErrorStatus.NOT_ENOUGH_BALANCE)
+	}
+
+	@Test
+	@DisplayName("잔액 차감 - 동시 수행할 시 동시성 제어 테스트")
+	fun balanceDecreaseConcurrency() {
+		// 10,000 잔액 보유한 사용자에 대해 3000 씩 5번 동시 차감 수행
+		// 예상 성공 카운트 3, 실패 카운트 2, 남은 잔액 1000
+		val balance = Balance(1L, 10000)
+		balanceRepository.save(balance)
+
+		val executor = Executors.newFixedThreadPool(5)
+		val countDownLatch = CountDownLatch(5)
+		val successCount = AtomicInteger(0) // 성공 카운트
+		val failCount = AtomicInteger(0)    // 실패 카운트
+
+		try {
+			repeat(5) {
+				executor.submit {
+					try {
+						balanceService.updateAmountDecrease(1L, 3000)
+						successCount.incrementAndGet()
+					} catch (e: BadRequestException) {
+						failCount.incrementAndGet()
+					} finally {
+						countDownLatch.countDown()
+					}
+				}
+			}
+
+			countDownLatch.await()
+
+			val actual = balanceService.getByUserIdWithLock(1L)
+
+			assertThat(actual.amount).isEqualTo(1000)
+			assertThat(successCount.get()).isEqualTo(3)
+			assertThat(failCount.get()).isEqualTo(2)
+		} finally {
+			executor.shutdown()
+		}
+	}
+
+	@Test
+	@DisplayName("잔액 충전 - 한 번 충전 수행")
+	fun balanceChargeOnce() {
+		val balance = Balance(1L, 5000)
+		balanceRepository.save(balance)
+
+		balanceService.updateAmountCharge(1L, 10000)
+		val actual = balanceService.getByUserIdWithLock(1L)
+
+		assertThat(actual.amount).isEqualTo(15000)
+	}
+
+	@Test
+	@DisplayName("잔액 충전 - 충전 금액이 마이너스일 경우 예외 케이스")
+	fun shouldFailChargeAmountNegative() {
+		val balance = Balance(1L, 5000)
+		balanceRepository.save(balance)
+
+		assertThatThrownBy { balanceService.updateAmountCharge(1L, -10000) }
+			.isInstanceOf(BadRequestException::class.java)
+			.extracting("errorStatus")
+			.isEqualTo(ErrorStatus.CHARGED_AMOUNT_ERROR)
+	}
+
+	@Test
+	@DisplayName("잔액 충전 - 동시 수행할 경우 동시성 제어 테스트")
+	fun balanceChargeConcurrency() {
+		val balance = Balance(1L, 0)
+		balanceRepository.save(balance)
+
+		val executor = Executors.newFixedThreadPool(5)
+		val countDownLatch = CountDownLatch(5)
+
+		try {
+			repeat(5) {
+				executor.submit {
+					try {
+						balanceService.updateAmountCharge(1L, 10000)
+					} finally {
+						countDownLatch.countDown()
+					}
+				}
+			}
+
+			countDownLatch.await()
+
+			val actual = balanceService.getByUserIdWithLock(1L)
+
+			assertThat(actual.amount).isEqualTo(50000)
+		} finally {
+			executor.shutdown()
+		}
+	}
+}

--- a/src/test/kotlin/com/example/hhplus_ecommerce/domain/cart/CartServiceIntegrationTest.kt
+++ b/src/test/kotlin/com/example/hhplus_ecommerce/domain/cart/CartServiceIntegrationTest.kt
@@ -1,0 +1,71 @@
+package com.example.hhplus_ecommerce.domain.cart
+
+import com.example.hhplus_ecommerce.domain.cart.dto.CartDto
+import com.example.hhplus_ecommerce.infrastructure.cart.CartJpaRepository
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.time.LocalDateTime
+
+@SpringBootTest
+class CartServiceIntegrationTest {
+	@Autowired private lateinit var cartService: CartService
+	@Autowired private lateinit var cartRepository: CartJpaRepository
+
+	@BeforeEach
+	fun clearDB() {
+		cartRepository.deleteAll()
+	}
+
+	@Test
+	@DisplayName("장바구니 상품 추가 기능 테스트")
+	fun addProductCart() {
+		// 상품 2개 장바구니에 추가
+		val userId = 1L
+		cartService.addProductCart(CartDto(0, userId, 1L, 1, LocalDateTime.now()))
+		cartService.addProductCart(CartDto(0, userId, 5L, 2, LocalDateTime.now()))
+
+		val actual = cartService.getAllCartsByUser(userId)
+
+		assertThat(actual.size).isEqualTo(2)
+		assertThat(actual[0].productDetailId).isEqualTo(1L)
+		assertThat(actual[0].quantity).isEqualTo(1)
+		assertThat(actual[1].productDetailId).isEqualTo(5L)
+		assertThat(actual[1].quantity).isEqualTo(2)
+	}
+
+	@Test
+	@DisplayName("장바구니 상품 삭제 기능 테스트")
+	fun deleteCartByUserProduct() {
+		// 상품 2개 추가한 후 상품 1개 삭제하기
+		val userId = 1L
+		cartService.addProductCart(CartDto(0, userId, 1L, 1, LocalDateTime.now()))
+		cartService.addProductCart(CartDto(0, userId, 5L, 2, LocalDateTime.now()))
+
+		cartService.deleteCartByUserProduct(userId, 1L)
+
+		val actual = cartService.getAllCartsByUser(userId)
+
+		assertThat(actual.size).isEqualTo(1)
+		assertThat(actual[0].productDetailId).isEqualTo(5L)
+		assertThat(actual[0].quantity).isEqualTo(2)
+	}
+
+	@Test
+	@DisplayName("해당 사용자에 대한 장바구니 모두 삭제")
+	fun deleteAllCartByUser() {
+		// 상품 2개 추가한 후 상품 모두 삭제하기
+		val userId = 1L
+		cartService.addProductCart(CartDto(0, userId, 1L, 1, LocalDateTime.now()))
+		cartService.addProductCart(CartDto(0, userId, 5L, 2, LocalDateTime.now()))
+
+		cartService.deleteCartByUser(userId)
+
+		val actual = cartService.getAllCartsByUser(userId)
+
+		assertThat(actual.size).isEqualTo(0)
+	}
+}

--- a/src/test/kotlin/com/example/hhplus_ecommerce/domain/order/OrderServiceIntegrationTest.kt
+++ b/src/test/kotlin/com/example/hhplus_ecommerce/domain/order/OrderServiceIntegrationTest.kt
@@ -1,0 +1,83 @@
+package com.example.hhplus_ecommerce.domain.order
+
+import com.example.hhplus_ecommerce.domain.order.dto.OrderDto
+import com.example.hhplus_ecommerce.domain.order.dto.OrderItemDto
+import com.example.hhplus_ecommerce.infrastructure.order.OrderItemJpaRepository
+import com.example.hhplus_ecommerce.infrastructure.order.OrderJpaRepository
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.time.LocalDateTime
+
+@SpringBootTest
+class OrderServiceIntegrationTest {
+	@Autowired private lateinit var orderService: OrderService
+	@Autowired private lateinit var orderRepository: OrderJpaRepository
+	@Autowired private lateinit var orderItemRepository: OrderItemJpaRepository
+
+	@BeforeEach
+	fun clearDB() {
+		orderRepository.deleteAll()
+		orderItemRepository.deleteAll()
+	}
+
+	@Test
+	@DisplayName("주문 정보 저장하기 기능 테스트")
+	fun registerOrder() {
+		val orderDto = OrderDto(
+			0,
+			1L,
+			LocalDateTime.now(),
+			10000,
+			OrderStatus.ORDER_COMPLETE,
+			LocalDateTime.now(),
+			LocalDateTime.now()
+		)
+
+		val orderId = orderService.registerOrder(orderDto).id
+
+		val actual = orderService.getOrderById(orderId)
+
+		assertThat(actual.totalPrice).isEqualTo(10000)
+		assertThat(actual.orderStatus).isEqualTo(OrderStatus.ORDER_COMPLETE)
+	}
+
+	@Test
+	@DisplayName("주문 상품 목록 저장하기 기능 테스트")
+	fun registerOrderItems() {
+		val orderItemDtos = listOf(
+			OrderItemDto(0, 1L, 1L, 1, 1000, LocalDateTime.now()),
+			OrderItemDto(0, 1L, 2L, 2, 5000, LocalDateTime.now()),
+		)
+
+		orderService.registerOrderItems(orderItemDtos)
+
+		val actual = orderItemRepository.findAllByOrderId(1L)
+
+		assertThat(actual.size).isEqualTo(2)
+	}
+
+	@Test
+	@DisplayName("주문 상태 업데이트 기능 테스트")
+	fun updateOrderStatus() {
+		val orderDto = OrderDto(
+			0,
+			1L,
+			LocalDateTime.now(),
+			10000,
+			OrderStatus.ORDER_WAIT,
+			LocalDateTime.now(),
+			LocalDateTime.now()
+		)
+		val orderId = orderService.registerOrder(orderDto).id
+
+		orderService.updateOrderStatus(orderId, OrderStatus.ORDER_COMPLETE)
+
+		val actual = orderService.getOrderById(orderId)
+
+		assertThat(actual.orderStatus).isEqualTo(OrderStatus.ORDER_COMPLETE)
+	}
+}

--- a/src/test/kotlin/com/example/hhplus_ecommerce/domain/product/ProductServiceIntegrationTest.kt
+++ b/src/test/kotlin/com/example/hhplus_ecommerce/domain/product/ProductServiceIntegrationTest.kt
@@ -6,6 +6,7 @@ import com.example.hhplus_ecommerce.infrastructure.product.ProductJpaRepository
 import com.example.hhplus_ecommerce.infrastructure.product.entity.Product
 import com.example.hhplus_ecommerce.infrastructure.product.entity.ProductDetail
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -18,8 +19,14 @@ import java.util.concurrent.atomic.AtomicInteger
 @SpringBootTest
 class ProductServiceIntegrationTest {
 	@Autowired private lateinit var productService: ProductService
-	@Autowired private lateinit var productJpaRepository: ProductJpaRepository
-	@Autowired private lateinit var productDetailJpaRepository: ProductDetailJpaRepository
+	@Autowired private lateinit var productRepository: ProductJpaRepository
+	@Autowired private lateinit var productDetailRepository: ProductDetailJpaRepository
+
+	@BeforeEach
+	fun clearDB() {
+		productRepository.deleteAll()
+		productDetailRepository.deleteAll()
+	}
 
 	@Test
 	@DisplayName("상품 목록 조회 - 페이징하여 상품 목록 조회")
@@ -33,16 +40,16 @@ class ProductServiceIntegrationTest {
 
 	private fun givenProducts(size: Int) {
 		for (i in 1..size) {
-			val productId = productJpaRepository.save(Product("상품${i}", "{i}번 상품")).id
-			productDetailJpaRepository.save(ProductDetail(productId, 1000, 100, ProductCategory.CLOTHES))
+			val productId = productRepository.save(Product("상품${i}", "{i}번 상품")).id
+			productDetailRepository.save(ProductDetail(productId, 1000, 100, ProductCategory.CLOTHES))
 		}
 	}
 
 	@Test
 	@DisplayName("특정 상품 조회하기")
 	fun getProductInfo() {
-		val productId = productJpaRepository.save(Product("상품 A", "A 상품")).id
-		productDetailJpaRepository.save(ProductDetail(productId, 1000, 100, ProductCategory.CLOTHES))
+		val productId = productRepository.save(Product("상품 A", "A 상품")).id
+		productDetailRepository.save(ProductDetail(productId, 1000, 100, ProductCategory.CLOTHES))
 
 		val actual = productService.getProductInfoById(productId)
 
@@ -56,8 +63,8 @@ class ProductServiceIntegrationTest {
 	fun quantityDecreaseConcurrency() {
 		// 상품 재고 3개에 대해 5번 동시 차감 요청 시
 		// 예상 성공 카운트 3, 실패 카운트 2, 남은 재고양 0
-		val productId = productJpaRepository.save(Product("상품 A", "A 상품")).id
-		val detailId = productDetailJpaRepository.save(ProductDetail(productId, 1000, 3, ProductCategory.CLOTHES)).id
+		val productId = productRepository.save(Product("상품 A", "A 상품")).id
+		val detailId = productDetailRepository.save(ProductDetail(productId, 1000, 3, ProductCategory.CLOTHES)).id
 
 		val executor = Executors.newFixedThreadPool(5)
 		val countDownLatch = CountDownLatch(5)

--- a/src/test/kotlin/com/example/hhplus_ecommerce/domain/product/ProductServiceIntegrationTest.kt
+++ b/src/test/kotlin/com/example/hhplus_ecommerce/domain/product/ProductServiceIntegrationTest.kt
@@ -1,0 +1,92 @@
+package com.example.hhplus_ecommerce.domain.product
+
+import com.example.hhplus_ecommerce.exception.BadRequestException
+import com.example.hhplus_ecommerce.infrastructure.product.ProductDetailJpaRepository
+import com.example.hhplus_ecommerce.infrastructure.product.ProductJpaRepository
+import com.example.hhplus_ecommerce.infrastructure.product.entity.Product
+import com.example.hhplus_ecommerce.infrastructure.product.entity.ProductDetail
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+@SpringBootTest
+class ProductServiceIntegrationTest {
+	@Autowired private lateinit var productService: ProductService
+	@Autowired private lateinit var productJpaRepository: ProductJpaRepository
+	@Autowired private lateinit var productDetailJpaRepository: ProductDetailJpaRepository
+
+	@Test
+	@DisplayName("상품 목록 조회 - 페이징하여 상품 목록 조회")
+	fun getAllProductsWithPaging() {
+		givenProducts(5)
+
+		val actual = productService.getAllProductInfosWithPaging(PageRequest.of(0, 3))
+
+		assertThat(actual.size).isEqualTo(3)
+	}
+
+	private fun givenProducts(size: Int) {
+		for (i in 1..size) {
+			val productId = productJpaRepository.save(Product("상품${i}", "{i}번 상품")).id
+			productDetailJpaRepository.save(ProductDetail(productId, 1000, 100, ProductCategory.CLOTHES))
+		}
+	}
+
+	@Test
+	@DisplayName("특정 상품 조회하기")
+	fun getProductInfo() {
+		val productId = productJpaRepository.save(Product("상품 A", "A 상품")).id
+		productDetailJpaRepository.save(ProductDetail(productId, 1000, 100, ProductCategory.CLOTHES))
+
+		val actual = productService.getProductInfoById(productId)
+
+		assertThat(actual.price).isEqualTo(1000)
+		assertThat(actual.stockQuantity).isEqualTo(100)
+		assertThat(actual.name).isEqualTo("상품 A")
+	}
+
+	@Test
+	@DisplayName("상품 재고 차감 - 동시에 재고 차감 시 동시성 제어 테스트")
+	fun quantityDecreaseConcurrency() {
+		// 상품 재고 3개에 대해 5번 동시 차감 요청 시
+		// 예상 성공 카운트 3, 실패 카운트 2, 남은 재고양 0
+		val productId = productJpaRepository.save(Product("상품 A", "A 상품")).id
+		val detailId = productDetailJpaRepository.save(ProductDetail(productId, 1000, 3, ProductCategory.CLOTHES)).id
+
+		val executor = Executors.newFixedThreadPool(5)
+		val countDownLatch = CountDownLatch(5)
+		val successCount = AtomicInteger(0) // 성공 카운트
+		val failCount = AtomicInteger(0)    // 실패 카운트
+
+		try {
+			repeat(5) {
+				executor.submit {
+					try {
+						productService.updateProductQuantityDecrease(detailId, 1)
+						successCount.incrementAndGet()
+					} catch (e: BadRequestException) {
+						failCount.incrementAndGet()
+					} finally {
+						countDownLatch.countDown()
+					}
+				}
+			}
+
+			countDownLatch.await()
+
+			val actual = productService.getProductInfoById(productId)
+
+			assertThat(actual.stockQuantity).isEqualTo(0)
+			assertThat(successCount.get()).isEqualTo(3)
+			assertThat(failCount.get()).isEqualTo(2)
+		} finally {
+			executor.shutdown()
+		}
+	}
+}

--- a/src/test/kotlin/com/example/hhplus_ecommerce/usecase/order/OrderFacadeIntegrationTest.kt
+++ b/src/test/kotlin/com/example/hhplus_ecommerce/usecase/order/OrderFacadeIntegrationTest.kt
@@ -1,0 +1,80 @@
+package com.example.hhplus_ecommerce.usecase.order
+
+import com.example.hhplus_ecommerce.domain.order.dto.OrderItemInfo
+import com.example.hhplus_ecommerce.domain.product.ProductCategory
+import com.example.hhplus_ecommerce.domain.product.ProductService
+import com.example.hhplus_ecommerce.exception.BadRequestException
+import com.example.hhplus_ecommerce.infrastructure.product.ProductDetailJpaRepository
+import com.example.hhplus_ecommerce.infrastructure.product.ProductJpaRepository
+import com.example.hhplus_ecommerce.infrastructure.product.entity.Product
+import com.example.hhplus_ecommerce.infrastructure.product.entity.ProductDetail
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+@SpringBootTest
+class OrderFacadeIntegrationTest {
+	@Autowired private lateinit var orderFacade: OrderFacade
+	@Autowired private lateinit var productService: ProductService
+	@Autowired private lateinit var productJpaRepository: ProductJpaRepository
+	@Autowired private lateinit var productDetailJpaRepository: ProductDetailJpaRepository
+
+	@Test
+	@DisplayName("상품에 대한 주문 단건 요청")
+	fun productOrderRequestOnce() {
+		val productId = productJpaRepository.save(Product("상품 A", "A 상품")).id
+		val detailId = productDetailJpaRepository.save(ProductDetail(productId, 1000, 100, ProductCategory.CLOTHES)).id
+
+		val orderInfo = orderFacade.productOrder(1L, listOf(OrderItemInfo(detailId, 50)))
+		val productInfo = productService.getProductInfoById(productId)
+
+		assertThat(orderInfo.totalPrice).isEqualTo(50000)
+		assertThat(orderInfo.orderItems.size).isEqualTo(1)
+		assertThat(orderInfo.orderItems[0].quantity).isEqualTo(50)
+		assertThat(productInfo.stockQuantity).isEqualTo(50)
+	}
+
+	@Test
+	@DisplayName("주문 - 한 상품에 대한 동시 주문 요청 동시성 제어 테스트")
+	fun productOrderConcurrency() {
+		// 재고 20개 존재하는 상품에 대해 30번 주문 요청
+		// 예상 성공 카운트 20, 실패 카운트 10, 남은 재고량 0
+		val productId = productJpaRepository.save(Product("상품 A", "A 상품")).id
+		val detailId = productDetailJpaRepository.save(ProductDetail(productId, 1000, 20, ProductCategory.CLOTHES)).id
+
+		val executor = Executors.newFixedThreadPool(30)
+		val countDownLatch = CountDownLatch(30)
+		val successCount = AtomicInteger(0) // 성공 카운트
+		val failCount = AtomicInteger(0)    // 실패 카운트
+
+		try {
+			repeat(30) {
+				executor.submit {
+					try {
+						orderFacade.productOrder(1L, listOf(OrderItemInfo(detailId, 1)))
+						successCount.incrementAndGet()
+					} catch (e: BadRequestException) {
+						failCount.incrementAndGet()
+					} finally {
+						countDownLatch.countDown()
+					}
+				}
+			}
+
+			countDownLatch.await()
+
+			val actual = productService.getProductInfoById(productId)
+
+			assertThat(actual.stockQuantity).isEqualTo(0)
+			assertThat(successCount.get()).isEqualTo(20)
+			assertThat(failCount.get()).isEqualTo(10)
+		} finally {
+			executor.shutdown()
+		}
+	}
+}

--- a/src/test/kotlin/com/example/hhplus_ecommerce/usecase/payment/PaymentFacadeIntegrationTest.kt
+++ b/src/test/kotlin/com/example/hhplus_ecommerce/usecase/payment/PaymentFacadeIntegrationTest.kt
@@ -1,0 +1,97 @@
+package com.example.hhplus_ecommerce.usecase.payment
+
+import com.example.hhplus_ecommerce.domain.balance.BalanceService
+import com.example.hhplus_ecommerce.domain.order.OrderService
+import com.example.hhplus_ecommerce.domain.order.OrderStatus
+import com.example.hhplus_ecommerce.exception.BadRequestException
+import com.example.hhplus_ecommerce.infrastructure.balance.BalanceHistoryJpaRepository
+import com.example.hhplus_ecommerce.infrastructure.balance.BalanceJpaRepository
+import com.example.hhplus_ecommerce.infrastructure.balance.entity.Balance
+import com.example.hhplus_ecommerce.infrastructure.order.OrderJpaRepository
+import com.example.hhplus_ecommerce.infrastructure.order.entity.OrderTable
+import com.example.hhplus_ecommerce.infrastructure.payment.PaymentJpaRepository
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.time.LocalDateTime
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+@SpringBootTest
+class PaymentFacadeIntegrationTest {
+	@Autowired private lateinit var paymentFacade: PaymentFacade
+	@Autowired private lateinit var orderService: OrderService
+	@Autowired private lateinit var balanceService: BalanceService
+	@Autowired private lateinit var balanceRepository: BalanceJpaRepository
+	@Autowired private lateinit var balanceHistoryRepository: BalanceHistoryJpaRepository
+	@Autowired private lateinit var paymentRepository: PaymentJpaRepository
+	@Autowired private lateinit var orderRepository: OrderJpaRepository
+
+	@BeforeEach
+	fun clearDB() {
+		balanceRepository.deleteAll()
+		balanceHistoryRepository.deleteAll()
+		paymentRepository.deleteAll()
+		orderRepository.deleteAll()
+	}
+
+	@Test
+	@DisplayName("결제 요청 - 외부 데이터 플랫폼 통신 중 예외 발생해도 트랜잭션 적용 영향 없는지 테스트")
+	fun orderPaymentOnce() {
+		val userId = 1L
+		val orderId = orderRepository.save(OrderTable(userId, LocalDateTime.now(), 10000, OrderStatus.ORDER_COMPLETE)).id
+		balanceRepository.save(Balance(userId, 10000))
+
+		paymentFacade.orderPayment(userId, orderId)
+		val orderDto = orderService.getOrderById(orderId)
+		val balanceDto = balanceService.getByUserIdWithLock(userId)
+
+		// 기존 잔액 10000 - 결제 금액 10000 = 남은 잔액 0
+		assertThat(balanceDto.amount).isEqualTo(0)
+		// 주문 상태가 PAYMENT_COMPLETE(결제 완료)로 업데이트 되었는지 확인
+		assertThat(orderDto.orderStatus).isEqualTo(OrderStatus.PAYMENT_COMPLETE)
+	}
+
+	@Test
+	@DisplayName("결제 요청 - 동시에 결제 요청 시 동시성 제어 테스트")
+	fun orderPaymentConcurrency() {
+		// 잔액 50000이 있고, 주문할 금액이 12000씩 10번 동시에 요청할 때
+		// 예상 성공 카운트 4, 실패 카운트 6, 남은 잔액 2000
+		val userId = 1L
+		val orderId = orderRepository.save(OrderTable(userId, LocalDateTime.now(), 12000, OrderStatus.ORDER_COMPLETE)).id
+		balanceRepository.save(Balance(userId, 50000))
+
+		val executor = Executors.newFixedThreadPool(10)
+		val countDownLatch = CountDownLatch(10)
+		val successCount = AtomicInteger(0) // 성공 카운트
+		val failCount = AtomicInteger(0)    // 실패 카운트
+
+		try {
+			repeat(10) {
+				executor.submit {
+					try {
+						paymentFacade.orderPayment(userId, orderId)
+						successCount.incrementAndGet()
+					} catch (e: BadRequestException) {
+						failCount.incrementAndGet()
+					} finally {
+						countDownLatch.countDown()
+					}
+				}
+			}
+			countDownLatch.await()
+
+			val balanceDto = balanceService.getByUserIdWithLock(userId)
+
+			assertThat(balanceDto.amount).isEqualTo(2000)
+			assertThat(successCount.get()).isEqualTo(4)
+			assertThat(failCount.get()).isEqualTo(6)
+		} finally {
+			executor.shutdown()
+		}
+	}
+}

--- a/src/test/kotlin/com/example/hhplus_ecommerce/usecase/statistics/StatisticsFacadeIntegrationTest.kt
+++ b/src/test/kotlin/com/example/hhplus_ecommerce/usecase/statistics/StatisticsFacadeIntegrationTest.kt
@@ -1,0 +1,85 @@
+package com.example.hhplus_ecommerce.usecase.statistics
+
+import com.example.hhplus_ecommerce.domain.order.OrderService
+import com.example.hhplus_ecommerce.domain.order.dto.OrderItemDto
+import com.example.hhplus_ecommerce.domain.product.ProductCategory
+import com.example.hhplus_ecommerce.domain.product.ProductService
+import com.example.hhplus_ecommerce.infrastructure.order.OrderItemJpaRepository
+import com.example.hhplus_ecommerce.infrastructure.order.OrderJpaRepository
+import com.example.hhplus_ecommerce.infrastructure.product.ProductDetailJpaRepository
+import com.example.hhplus_ecommerce.infrastructure.product.ProductJpaRepository
+import com.example.hhplus_ecommerce.infrastructure.product.entity.Product
+import com.example.hhplus_ecommerce.infrastructure.product.entity.ProductDetail
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.time.LocalDateTime
+
+@SpringBootTest
+class StatisticsFacadeIntegrationTest {
+	@Autowired private lateinit var statisticsFacade: StatisticsFacade
+	@Autowired private lateinit var orderService: OrderService
+	@Autowired private lateinit var productService: ProductService
+	@Autowired private lateinit var orderRepository: OrderJpaRepository
+	@Autowired private lateinit var orderItemRepository: OrderItemJpaRepository
+	@Autowired private lateinit var productRepository: ProductJpaRepository
+	@Autowired private lateinit var productDetailRepository: ProductDetailJpaRepository
+
+	@BeforeEach
+	fun clearDB() {
+		orderRepository.deleteAll()
+		orderItemRepository.deleteAll()
+		productRepository.deleteAll()
+		productDetailRepository.deleteAll()
+	}
+
+	@Test
+	@DisplayName("통계성 상위 상품 조회 - 3일 간 상위 5개 상품 정보 조회하기 기능")
+	fun getTopProductsStatistics() {
+		givenOrderItems()
+
+		val actual = statisticsFacade.getTopOrderProductStatistics(3, 5)
+
+		assertThat(actual.size).isEqualTo(5)
+		assertThat(actual[0].name).isEqualTo("상품A")
+		assertThat(actual[0].totalSold).isEqualTo(55)
+		assertThat(actual[1].name).isEqualTo("상품B")
+		assertThat(actual[1].totalSold).isEqualTo(40)
+		assertThat(actual[2].name).isEqualTo("상품C")
+		assertThat(actual[2].totalSold).isEqualTo(30)
+		assertThat(actual[3].name).isEqualTo("상품D")
+		assertThat(actual[3].totalSold).isEqualTo(20)
+		assertThat(actual[4].name).isEqualTo("상품E")
+		assertThat(actual[4].totalSold).isEqualTo(10)
+	}
+
+	private fun givenOrderItems() {
+		val productId1 = productRepository.save(Product("상품A", "상품A 설명")).id
+		val productId2 = productRepository.save(Product("상품B", "상품B 설명")).id
+		val productId3 = productRepository.save(Product("상품C", "상품C 설명")).id
+		val productId4 = productRepository.save(Product("상품D", "상품D 설명")).id
+		val productId5 = productRepository.save(Product("상품E", "상품E 설명")).id
+		val productId6 = productRepository.save(Product("상품F", "상품F 설명")).id
+
+		val detailId1 = productDetailRepository.save(ProductDetail(productId1, 50000, 100, ProductCategory.CLOTHES)).id
+		val detailId2 = productDetailRepository.save(ProductDetail(productId2, 30000, 100, ProductCategory.COSMETICS)).id
+		val detailId3 = productDetailRepository.save(ProductDetail(productId3, 100000, 100, ProductCategory.ELECTRONICS)).id
+		val detailId4 = productDetailRepository.save(ProductDetail(productId4, 1000, 100, ProductCategory.COSMETICS)).id
+		val detailId5 = productDetailRepository.save(ProductDetail(productId5, 1000, 100, ProductCategory.COSMETICS)).id
+		val detailId6 = productDetailRepository.save(ProductDetail(productId6, 2000, 100, ProductCategory.COSMETICS)).id
+
+		val orderItemDtos = listOf(
+			OrderItemDto(0, 1L, detailId1, 50, 2500000, LocalDateTime.now()),
+			OrderItemDto(0, 1L, detailId2, 40, 1200000, LocalDateTime.now()),
+			OrderItemDto(0, 2L, detailId3, 30, 3000000, LocalDateTime.now()),
+			OrderItemDto(0, 3L, detailId4, 20, 20000, LocalDateTime.now()),
+			OrderItemDto(0, 4L, detailId5, 10, 10000, LocalDateTime.now()),
+			OrderItemDto(0, 4L, detailId6, 5, 5000, LocalDateTime.now()),
+			OrderItemDto(0, 5L, detailId1, 5, 250000, LocalDateTime.now()),
+		)
+		orderService.registerOrderItems(orderItemDtos)
+	}
+}


### PR DESCRIPTION
### 변경 사항
* 비즈니스 로직 통합 테스트 작성
    * 비용 충전 / 차감
    * 상품 조회 / 재고 차감
    * 주문
    * 결제
    * 장바구니 상품 추가 / 제거
    * 상위 상품 통계 조회
* API에 Facade 및 Service 주입하여 비즈니스 로직 붙이기
* 테스트 진행하면서 오류가 발생했던 문법 오류 등 수정
* 외부 데이터 플랫폼 페이크 객체에서 이벤트 Listening 시 임의의 예외를 던지도록 수정

### 배경
* 상품 재고 차감, 주문, 결제, 비용 차감과 같이 동시성 제어가 필요한 기능에 대해 `CountDownLatch`로 동시 요청 테스트를 진행하여 성공 카운트와 실패 카운트, 최종 데이터 정합성을 검사했습니다.
* 결제 기능에서 결제 완료 후 외부 데이터 플랫폼에 전송할 때, 전송 요청이 실패하더라도 비즈니스 로직 트랜잭션은 정상적으로 커밋되는 부분을 검사하기 위해 외부 데이터 플랫폼용 비동기 이벤트에서 임의적으로 예외를 발생시키도록 했습니다.

### Issue
* #13 
