### PR TITLE
modify: #30 API 인터셉터에 요청 본문 변환 중 예외 처리 추가

### DIFF
--- a/src/main/kotlin/com/example/hhplus_ecommerce/api/interceptor/ApiLoggingInterceptor.kt
+++ b/src/main/kotlin/com/example/hhplus_ecommerce/api/interceptor/ApiLoggingInterceptor.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import mu.KotlinLogging
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.HandlerInterceptor
+import org.springframework.web.util.ContentCachingRequestWrapper
 import java.util.*
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
@@ -13,16 +14,23 @@ class ApiLoggingInterceptor : HandlerInterceptor {
 	private val logger = KotlinLogging.logger {}
 
 	override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
-		when {
-			Objects.equals(request.method, "POST") -> {
-				val inputMap = ObjectMapper().readValue(request.inputStream, Map::class.java)
+		val wrappedRequest = if (request is ContentCachingRequestWrapper) request else ContentCachingRequestWrapper(request)
 
-				logger.info("요청 URL: {}", request.requestURL)
-				logger.info("요청 정보: {}", inputMap)
+		when {
+			Objects.equals(wrappedRequest.method, "POST") && wrappedRequest.contentType?.contains("application/json") == true -> {
+				try {
+					val body = String(wrappedRequest.contentAsByteArray, Charsets.UTF_8)
+					val inputMap = ObjectMapper().readValue(body, Map::class.java)
+
+					logger.info("요청 URL: {}", wrappedRequest.requestURL)
+					logger.info("요청 정보: {}", inputMap)
+				} catch (e: Exception) {
+					logger.warn("요청 본문을 읽는 중 오류 발생: {}", e.message)
+				}
 			}
 			else -> {
-				logger.info("요청 URL: {}", request.requestURL)
-				logger.info("요청 정보: {}", request.queryString)
+				logger.info("요청 URL: {}", wrappedRequest.requestURL)
+				logger.info("요청 정보: {}", wrappedRequest.queryString)
 			}
 		}
 		return true


### PR DESCRIPTION
### 변경 사항
* API 인터셉터에서 요청 분문 변환 로직에 대한 예외 처리 추가

### 배경
* 기존 API 인터셉터에서 API 요청 시 400 에러가 발생

### 관련 이슈
* #30 
* 현재 요청 본문이 존재하는데 예외가 발생하는 문제가 있어 추후 재수정 필요해보임
