### PR TITLE
#39 CI workflows gradle build 중 테스트 수행 제외

### DIFF
--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build with gradle
         uses: gradle/gradle-build-action@v3
         with:
-          arguments: clean build
+          arguments: clean build -x test
 
       # Docker build & push
       # GITHUB_SHA : GitHub 커밋 앞 7자리


### PR DESCRIPTION
### 변경 사항
* CI workflows gradle build 중 테스트 수행 제외

### 배경
* GitHub Actions Agent에서 Test 수행 환경 구성 전으로 우선 gradle build 시 테스트 제외
